### PR TITLE
Feat: o botão 'IA Análise' deve exibir apenas o ícone no mobile e outras melhorias

### DIFF
--- a/src/components/custom/IAAnaliseButton.vue
+++ b/src/components/custom/IAAnaliseButton.vue
@@ -88,6 +88,6 @@ const handleClick = async () => {
   >
     <Loader2 v-if="iaAnaliseStore.isLoading" class="w-4 h-4 animate-spin" />
     <Sparkles v-else class="w-4 h-4" />
-    IA Análise
+    <span class="hidden md:block">IA Análise</span>
   </Button>
 </template>

--- a/src/components/layout/LeftMenuComponent.vue
+++ b/src/components/layout/LeftMenuComponent.vue
@@ -5,6 +5,8 @@
     :openMobile="false"
     @update:modelValue="handleSidebarExpand"
     :collapsed="sidebarExpanded"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
   >
     <div
       v-if="authStore && authStore.user && !authStore.user.is_available"
@@ -787,7 +789,7 @@ const setActiveGroupProject = async (project: any) => {
   setTimeout(() => {
     configStore.loading = false;
     const isMobile = window.innerWidth < 768;
-    sidebarExpanded.value = !isMobile;
+    sidebarExpanded.value = false;
     document.body.style.overflow = "";
   }, 2000);
 };
@@ -819,6 +821,21 @@ const toggleCollapsed = (type: string) => {
 
 const handleSidebarExpand = (value: boolean) => {
   sidebarExpanded.value = value;
+};
+
+const onMouseEnter = () => {
+  const isMobile = window.innerWidth < 768;
+  if (!isMobile) {
+    sidebarExpanded.value = true;
+  }
+};
+
+const onMouseLeave = () => {
+  const isMobile = window.innerWidth < 768;
+  if (!isMobile) {
+    sidebarExpanded.value = false;
+    collapsed.value = "";
+  }
 };
 
 const toggleSidebar = () => {

--- a/src/components/ui/sidebar/Sidebar.vue
+++ b/src/components/ui/sidebar/Sidebar.vue
@@ -12,11 +12,10 @@ defineOptions({
 
 const props = withDefaults(defineProps<SidebarProps>(), {
   side: "left",
-  variant: "sidebar",
+  variant: "floating",
   collapsible: "offcanvas",
   collapsed: false,
 });
-
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
@@ -34,12 +33,6 @@ const updateCol = async ()=>{
     handleClose()
   }
 }
-
-onMounted(()=>{
-  if (!isMobile.value) {
-    handleOpen()
-  }
-})
 </script>
 
 <template>
@@ -86,35 +79,33 @@ onMounted(()=>{
   </Sheet>
 
   <div
-    v-else
-    class="group peer hidden md:block"
-    :data-state="state"
-    :data-collapsible="!collapsed ? collapsible : ''"
-    :data-variant="variant"
-    :data-side="side"
+      v-else
+      class="group peer hidden md:block"
+      :data-state="state"
+      :data-collapsible="!collapsed ? collapsible : ''"
+      :data-variant="variant"
+      :data-side="side"
   >
     <!-- This is what handles the sidebar gap on desktop  -->
     <div
-      :class="
-        cn(
-          'duration-200 relative h-svh  bg-transparent transition-[width] ease-linear',
-          side === 'left'
-            ? 'w-[--sidebar-width]'
-            : 'w-[440px]',
-          'group-data-[collapsible=offcanvas]:w-0',
-          'group-data-[side=right]:rotate-180',
-          variant === 'floating' || variant === 'inset'
-            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
-            : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]'
-        )
-      "
+        :class="
+            cn(
+              'duration-200 relative h-svh bg-transparent transition-[width] ease-linear',
+              collapsible === 'icon' ? 'w-[--sidebar-width-icon]' : (side === 'left' ? 'w-[--sidebar-width]' : 'w-[440px]'),
+              collapsible === 'offcanvas' ? 'w-0' : '',
+              'group-data-[side=right]:rotate-180',
+              (variant === 'floating' || variant === 'inset') && collapsible === 'icon'
+                ? 'w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
+                : ''
+            )
+          "
     />
     <div
-      :class="
-        cn(
-          'duration-200 fixed inset-y-0 z-10 hidden h-svh  transition-[left,right,width] ease-linear md:flex',
-          side === 'right' ? 'w-[440px]' : 'w-[--sidebar-width]',
-          side === 'left'
+        :class="
+            cn(
+              'duration-200 fixed inset-y-0 z-50 hidden h-svh transition-[left,right,width] ease-linear md:flex',
+              side === 'right' ? 'w-[440px]' : 'w-[--sidebar-width]',
+              side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(28rem*-1)]',          // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'

--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -27,7 +27,7 @@ const { toggleSidebar } = useSidebar();
       v-if="logo"
       :src="logoSrc"
       alt="Logo"
-      class="h-10 w-10 mr-2 md:hidden cursor-pointer"
+      class="h-12 w-12 mr-2 md:hidden cursor-pointer"
       @click="
         () => {
           toggle?.();

--- a/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/src/components/ui/sidebar/SidebarTrigger.vue
@@ -24,10 +24,10 @@ const { toggleSidebar } = useSidebar();
 <template>
   <div class="flex gap-2">
     <img
-        v-if="logo"
+      v-if="logo"
       :src="logoSrc"
       alt="Logo"
-      class="h-9 w-9 mr-2 md:hidden"
+      class="h-10 w-10 mr-2 md:hidden cursor-pointer"
       @click="
         () => {
           toggle?.();
@@ -35,26 +35,5 @@ const { toggleSidebar } = useSidebar();
         }
       "
     />
-    <Button
-      data-sidebar="trigger"
-      variant="ghost"
-      size="icon"
-      :class="cn('h-9 w-9', props.class)"
-      @click="
-        () => {
-          toggle?.();
-          toggleSidebar();
-        }
-      "
-    >
-      <template v-if="logoCustom">
-        <img :src="logoCustom" alt="Logo" class="h-9 w-9" />
-      </template>
-      <template v-else>
-        <PanelLeft  v-if="logo"/>
-        <PanelRight  v-else   />
-        <span class="sr-only">Toggle Sidebar</span>
-      </template>
-    </Button>
   </div>
 </template>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -3,13 +3,9 @@
     <LeftMenuComponent v-model:sidebarExpanded="sidebarExpanded" />
 
     <SidebarInset>
-      <header
-        class="flex sticky z-30 top-0 bg-background/5 backdrop-blur-md h-16 shrink-0 items-center gap-2 px-4"
-      >
-        <div class="flex items-center gap-2 w-full px-4">
-          <SidebarTrigger :logo="true" :toggle="toggleSidebar" class="-ml-1" />
-
-          <Separator orientation="vertical" class="mr-2 h-4 hidden md:block" />
+      <header class="flex sticky z-30 top-0 bg-background/5 backdrop-blur-md h-16 shrink-0 items-center gap-2 px-4">
+        <div class="flex items-center gap-2 w-full">
+          <SidebarTrigger :logo="true" :toggle="toggleSidebar" />
 
           <Breadcrumb class="flex-1">
             <BreadcrumbList class="flex flex-nowrap">

--- a/src/views/dashboard/Home.vue
+++ b/src/views/dashboard/Home.vue
@@ -2,11 +2,8 @@
   <div class="view-home pb-16 w-full">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-2 w-full mt-5">
       <div>
-        <div class="text-md">
-          {{ greeting() }}
-        </div>
         <div class="text-xl md:text-2xl lg:text-3xl font-semibold">
-          {{ user ? user.first_name : "" }}
+          {{ greeting() }} {{ user ? user.first_name : "" }}
         </div>
         <div
           class="text-xs md:text-sm"


### PR DESCRIPTION
* Na página Home - o botão "IA Análise" de exibir apenas o ícone no mobile
* Corrigir o botão atrás da logomarca do Projeto/Grupo
* Expandir e ocultar barra lateral ao passar o mouse sobre mesmo - quando em uso no Desktop
* Reduzir para uma linha a frase de boa-vindas
* Aumentar dimensão da logomarca Elevate no menu curto